### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,11 +2,11 @@
 /var/log/dieta
 ===============================
 
-.. image:: https://pypip.in/version/vld/badge.svg?style=flat
+.. image:: https://img.shields.io/pypi/v/vld.svg?style=flat
     :target: https://pypi.python.org/pypi/vld/
     :alt: Latest version
 
-.. image:: https://pypip.in/py_versions/vld/badge.svg?style=flat
+.. image:: https://img.shields.io/pypi/pyversions/vld.svg?style=flat
     :target: https://pypi.python.org/pypi/vld/
     :alt: Supported Python versions
 
@@ -16,7 +16,7 @@
 .. image:: https://coveralls.io/repos/pignacio/vld/badge.svg?branch=master
     :target: https://coveralls.io/r/pignacio/vld?branch=master
 
-.. image:: https://pypip.in/license/vld/badge.svg?style=flat
+.. image:: https://img.shields.io/pypi/l/vld.svg?style=flat
     :target: https://pypi.python.org/pypi/vld/
     :alt: License
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20vld))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `vld`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.